### PR TITLE
Add startup delay + update binary host + minor updates to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,30 +1,38 @@
 # CakeQOS-Merlin
-<b>Pre-reqs</b><br />
-    1. Currently only supports RT-86U & RT-AX88U running Merlin firmware<br />
-    2. Not recommended for connection up/down of 250Mbps or higher<br />
-    3. Disable QoS (any) - probably best to go to Admin/Privacy and "Withdraw" to be sure (note disables others stuff too)<br />
-    4. Entware<br />
-    5. USB Storage<br />
-    6. jffs<br />
-<br />
-<b>Tips</b><br />
-1. If you use connections like ADSL, VDSL, Docsis, learn about the overhead keyword. <br />
-    https://man7.org/linux/man-pages/man8/tc-cake.8.html<br />
-2. Use 90-95% of your line speed as upload/download limits<br />
-<br />
-<b>Install Example</b><br />
-    1. Download and apply permissions:<br />
-    /usr/sbin/curl --retry 3 "https://raw.githubusercontent.com/ttgapers/cakeqos-merlin/master/cake-qos.sh" -o "/jffs/scripts/cake-qos" && chmod 0755 /jffs/scripts/cake-qos<br />
-    2. Convert (just in case):<br />
-    dos2unix /jffs/scripts/cake-qos<br />
-    3. Change for your router model:<br />
-    /jffs/scripts/cake-qos install <b>ac86u</b><br />
-    4. Change for your linespeed and any overhead:<br />
-    /jffs/scripts/cake-qos enable <b>135</b>Mbit <b>13</b>Mbit <b>"docsis" "ack-filter"</b><br />
-    <br />
-    <b>Usage:</b> /jffs/scripts/cake-qos {install|enable|start|stop|disable} (install, enable and start have required parameters)<br />
-    <br />
-<b>CLI</b><br />
-    tc qdisc<br />
-    tc -s qdisc show dev eth0 (for upload)<br />
-    tc -s qdisc show dev ifb9eth0 (for download)<br />
+
+## Pre-requisites
+1. Currently only supports RT-86U & RT-AX88U running Merlin firmware
+2. Not recommended for connection up/down of 250Mbps or higher
+3. Disable QoS (any) - probably best to go to Admin/Privacy and "Withdraw" to be sure (note disables others stuff too)
+4. Entware
+5. USB Storage
+6. jffs
+
+## Tips
+1. If you use connections like ADSL, VDSL, Docsis, learn about the overhead keyword. 
+    https://man7.org/linux/man-pages/man8/tc-cake.8.html
+2. Use 90-95% of your line speed as upload/download limits
+
+## Install Example
+1. Download and apply permissions:
+> /usr/sbin/curl --retry 3 "https://raw.githubusercontent.com/ttgapers/cakeqos-merlin/master/cake-qos.sh" -o "/jffs/scripts/cake-qos" && chmod 0755 /jffs/scripts/cake-qos
+2. Convert (just in case):
+> dos2unix /jffs/scripts/cake-qos
+3. Change for your router model (`ac86u` or `ax88u`):
+> /jffs/scripts/cake-qos install **ac86u**
+4. Change for your linespeed and any overhead (assuming 135Mbit download, 13Mbit upload, "docsis ack-filter" as optional extra parameters; speeds can also be specified in `Kbit` units):
+> /jffs/scripts/cake-qos enable **135Mbit 13Mbit "docsis ack-filter"**
+
+## Usage
+
+> /jffs/scripts/cake-qos {install|enable|start|stop|disable}
+
+(install, enable and start have required parameters)
+    
+## CLI
+
+```
+tc qdisc
+tc -s qdisc show dev eth0 (for upload)
+tc -s qdisc show dev ifb9eth0 (for download)
+```

--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@
 
 ## Usage
 
-> /jffs/scripts/cake-qos {install|enable|start|stop|disable}
+> /jffs/scripts/cake-qos {install|enable|start|startnow|stop|disable}
 
-(install, enable and start have required parameters)
+(install, enable, start, and startnow have required parameters)
     
 ## CLI
 

--- a/cake-qos.sh
+++ b/cake-qos.sh
@@ -157,18 +157,23 @@ case $1 in
 		cake_start "${2}" "${3}" "${4}"
 		return 0
 		;;
+	startnow)
+		cake_start "${2}" "${3}" "${4}"
+		return 0
+		;;
 	stop)
 		cake_stop
 		return 0
 		;;
 	*)
-		echo "Usage: $SCRIPT_NAME {install|enable|start|stop|disable} (install, enable and start have required parameters)"
+		echo "Usage: $SCRIPT_NAME {install|enable|start|startnow|stop|disable} (install, enable, start, and startnow have required parameters)"
 		echo ""
-		echo "install: install necessary $SCRIPT_NAME binaries"
-		echo "enable:  start $SCRIPT_NAME and add to startup"
-		echo "start:   start $SCRIPT_NAME"
-		echo "stop:    stop $SCRIPT_NAME"
-		echo "disable: stop $SCRIPT_NAME and remove from startup"
+		echo "install:  install necessary $SCRIPT_NAME binaries"
+		echo "enable:   start $SCRIPT_NAME and add to startup"
+		echo "start:    start $SCRIPT_NAME (5 minute delay)"
+		echo "startnow: start $SCRIPT_NAME (no delay)"
+		echo "stop:     stop $SCRIPT_NAME"
+		echo "disable:  stop $SCRIPT_NAME and remove from startup"
 		return 1
 		;;
 esac

--- a/cake-qos.sh
+++ b/cake-qos.sh
@@ -74,8 +74,8 @@ case $1 in
 			FILE1="sched-cake-oot_2020-05-28-a5dccfd8-ax_aarch64-3.10.ipk"
 		fi
 		FILE2="tc-adv_4.16.0-git-20191110_aarch64-3.10.ipk"
-		/usr/sbin/curl --retry 3 "https://5m.ca/cake/${FILE1}" -o "/tmp/home/root/${FILE1}"
-		/usr/sbin/curl --retry 3 "https://5m.ca/cake/${FILE2}" -o "/tmp/home/root/${FILE2}"
+		/usr/sbin/curl --retry 3 "https://github.com/jkychn/cakeqos-merlin/raw/master/${FILE1}" -o "/tmp/home/root/${FILE1}"
+		/usr/sbin/curl --retry 3 "https://github.com/jkychn/cakeqos-merlin/raw/master/${FILE2}" -o "/tmp/home/root/${FILE2}"
 		/opt/bin/opkg install "/tmp/home/root/${FILE1}"
 		/opt/bin/opkg install "/tmp/home/root/${FILE2}"
 		rm "/tmp/home/root/${FILE1}"
@@ -151,6 +151,9 @@ case $1 in
 		return 0
 		;;
 	start)
+		logger "Cake Queue Management Delayed Start (in 5 mins)"
+		echo "Cake Queue Management Delayed Start (in 5 mins)"
+		sleep 300s
 		cake_start "${2}" "${3}" "${4}"
 		return 0
 		;;


### PR DESCRIPTION
I did a quick test and it seems the download URLs can be changed (I compared the MD5 sum).

Added 5 minute startup delay per testing with Jon21 re:properly starting up on device boot. Further testing should be done to test services-start (+ 5 min delay) against firewall-start (with/without a delay) to see which is more appropriate.

Minor formatting changes to readme to convert to markdown format.

EDIT: Second commit = add startnow mode (in case people want to start cake-qos via terminal, they don't need to wait 5 minutes). `start` is used in services-start (5 min delay). Noticed line endings in the .sh was CR/LF (Windows) which is incompatible with Asus so I converted it to LF (Unix). There shouldn't be any need to run dos2unix as long as we maintain the LF line ending.