### PR TITLE
V1.0.2

### DIFF
--- a/cake-qos.sh
+++ b/cake-qos.sh
@@ -734,12 +734,12 @@ case $1 in
 	*)
 		Print_Output "false" "Usage: $SCRIPT_NAME {start|stop|status|settings|update|install|uninstall}" "$WARN"
 		echo
-		Print_Output "false" "start:     configure and start $SCRIPT_NAME" "$PASS"
+		Print_Output "false" "start:     start $SCRIPT_NAME" "$PASS"
 		Print_Output "false" "stop:      stop $SCRIPT_NAME" "$PASS"
 		Print_Output "false" "status:    check the current status of $SCRIPT_NAME" "$PASS"
 		Print_Output "false" "settings:  configure settings for $SCRIPT_NAME" "$PASS"
-		Print_Output "false" "update:    update $SCRIPT_NAME binaries (if any available)" "$PASS"
-		Print_Output "false" "install:   only downloads and installs necessary $SCRIPT_NAME binaries" "$PASS"
+		Print_Output "false" "update:    update $SCRIPT_NAME & binaries (if available)" "$PASS"
+		Print_Output "false" "install:   install and configure $SCRIPT_NAME" "$PASS"
 		Print_Output "false" "uninstall: stop $SCRIPT_NAME, remove from startup, and remove cake binaries" "$PASS"
 	;;
 esac

--- a/cake-qos.sh
+++ b/cake-qos.sh
@@ -178,8 +178,8 @@ Cake_Start(){
 
 	# Migrate universal options to individual
 	if [ -n "${extraoptions:=}" ] && [ -z "$optionsdl" ] && [ -z "$optionsup" ]; then
-		optionsdl="${extraoptions:=}"
-		optionsup="${extraoptions:=}"
+		optionsdl="${extraoptions}"
+		optionsup="${extraoptions}"
 		Write_Config
 	fi
 
@@ -299,7 +299,7 @@ Cake_Menu(){
 	echo
 	echo "[e]  --> Exit"
 	echo
-	if Cake_CheckUpdates; then
+	if [ "$1" = "check" ] && Cake_CheckUpdates; then
 		Display_Line
 		echo "[*] $SCRIPT_NAME_FANCY update available!"
 	fi
@@ -463,7 +463,7 @@ Cake_Menu(){
 }
 
 if [ -z "$1" ]; then
-	Cake_Menu
+	Cake_Menu "check"
 fi
 
 if [ -n "$option1" ]; then

--- a/cake-qos.sh
+++ b/cake-qos.sh
@@ -343,7 +343,7 @@ Cake_Menu(){
 							break
 						;;
 						e|exit|back|menu)
-							unset "option1" "option2" "option3"
+							unset "option1" "option2"
 							clear
 							Cake_Menu
 							break

--- a/cake-qos.sh
+++ b/cake-qos.sh
@@ -515,7 +515,6 @@ case $1 in
 	;;
 	status)
 		if Cake_CheckStatus; then
-			Print_Output "false" "Running..." "$PASS"
 			case "$2" in
 				download)
 					tc -s qdisc show dev ifb9eth0
@@ -526,8 +525,13 @@ case $1 in
 				general)
 					Print_Output "false" "> Download Status:" "$PASS"
 					echo "$STATUS_DOWNLOAD"
+					echo
 					Print_Output "false" "> Upload Status:" "$PASS"
 					echo "$STATUS_UPLOAD"
+				;;
+				*)
+					echo "Command Not Recognized, Please Try Again"
+					echo; exit 2
 				;;
 			esac
 		else
@@ -569,6 +573,10 @@ case $1 in
 			;;
 			optionsup)
 				optionsup="$3"
+			;;
+			*)
+				echo "Command Not Recognized, Please Try Again"
+				echo; exit 2
 			;;
 		esac
 		Write_Config

--- a/cake-qos.sh
+++ b/cake-qos.sh
@@ -732,13 +732,14 @@ case $1 in
 		fi
 	;;
 	*)
-		Print_Output "false" "Usage: $SCRIPT_NAME {install|update|start|status|stop|uninstall} (start has required parameters)" "$WARN"
+		Print_Output "false" "Usage: $SCRIPT_NAME {start|stop|status|settings|update|install|uninstall}" "$WARN"
 		echo
-		Print_Output "false" "install:   only downloads and installs necessary $SCRIPT_NAME binaries" "$PASS"
-		Print_Output "false" "update:    update $SCRIPT_NAME binaries (if any available)" "$PASS"
 		Print_Output "false" "start:     configure and start $SCRIPT_NAME" "$PASS"
-		Print_Output "false" "status:    check the current status of $SCRIPT_NAME" "$PASS"
 		Print_Output "false" "stop:      stop $SCRIPT_NAME" "$PASS"
+		Print_Output "false" "status:    check the current status of $SCRIPT_NAME" "$PASS"
+		Print_Output "false" "settings:  configure settings for $SCRIPT_NAME" "$PASS"
+		Print_Output "false" "update:    update $SCRIPT_NAME binaries (if any available)" "$PASS"
+		Print_Output "false" "install:   only downloads and installs necessary $SCRIPT_NAME binaries" "$PASS"
 		Print_Output "false" "uninstall: stop $SCRIPT_NAME, remove from startup, and remove cake binaries" "$PASS"
 	;;
 esac

--- a/cake-qos.sh
+++ b/cake-qos.sh
@@ -498,6 +498,7 @@ fi
 
 if [ -n "$option1" ]; then
 	set "$option1" "$option2" "$option3"
+	echo "[$] $0 $*" | tr -s " "
 fi
 
 Display_Line

--- a/cake-qos.sh
+++ b/cake-qos.sh
@@ -320,6 +320,36 @@ Cake_Menu(){
 			;;
 			3)
 				option1="status"
+				while true; do
+					echo "Select Status Option:"
+					echo "[1]  --> Download Status"
+					echo "[2]  --> Upload Status"
+					echo "[3]  --> General Status"
+					echo
+					printf "[1-3]: "
+					read -r "menu2"
+					echo
+					case "$menu2" in
+						1)
+							option2="download"
+							break
+						;;
+						2)
+							option2="upload"
+							break
+						;;
+						3)
+							option2="general"
+							break
+						;;
+						e|exit|back|menu)
+							unset "option1" "option2" "option3"
+							clear
+							Cake_Menu
+							break
+						;;
+					esac
+				done
 				break
 			;;
 			4)
@@ -486,10 +516,20 @@ case $1 in
 	status)
 		if Cake_CheckStatus; then
 			Print_Output "false" "Running..." "$PASS"
-			Print_Output "false" "> Download Status:" "$PASS"
-			echo "$STATUS_DOWNLOAD"
-			Print_Output "false" "> Upload Status:" "$PASS"
-			echo "$STATUS_UPLOAD"
+			case "$2" in
+				download)
+					tc -s qdisc show dev ifb9eth0
+				;;
+				upload)
+					tc -s qdisc show dev eth0
+				;;
+				general)
+					Print_Output "false" "> Download Status:" "$PASS"
+					echo "$STATUS_DOWNLOAD"
+					Print_Output "false" "> Upload Status:" "$PASS"
+					echo "$STATUS_UPLOAD"
+				;;
+			esac
 		else
 			Print_Output "false" "Not running..." "$WARN"
 		fi


### PR DESCRIPTION
Remove hard exit on update
Change information prefix from [i] to [*]
Allow 0 as valid bandwidth setting (unlimited)
Add separate upload/download options
Remove Cake_Stop from start function
Don't show update check when in submenus
Additional status options (download & upload)
Don't allow malformed commands
Update malformed command output
Display CLI version of commands when using menu options